### PR TITLE
Expose API URL configuration in frontend

### DIFF
--- a/gestion-eleves-front/.env.example
+++ b/gestion-eleves-front/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for the frontend
+# Base URL of the backend API
+VITE_API_URL=http://localhost:3000

--- a/gestion-eleves-front/README.md
+++ b/gestion-eleves-front/README.md
@@ -67,3 +67,6 @@ export default tseslint.config([
   },
 ])
 ```
+
+## Environment variables
+Copy `.env.example` to `.env` and adjust `VITE_API_URL` to match your backend.

--- a/gestion-eleves-front/src/dataProvider.ts
+++ b/gestion-eleves-front/src/dataProvider.ts
@@ -2,7 +2,12 @@ import type { DataProvider } from "@refinedev/core";
 
 import axios from "axios";
 
-export const API_URL = "http://localhost:3000";
+/**
+ * Base URL of the backend API.
+ * Can be configured via the `VITE_API_URL` environment variable.
+ */
+export const API_URL =
+    (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:3000";
 const axiosInstance = axios.create({
     baseURL: API_URL,
 });


### PR DESCRIPTION
## Summary
- make the data provider read the API base URL from `VITE_API_URL`
- add example `.env` file for the frontend
- document the variable in the frontend README

## Testing
- `npm install` *(fails: 403 Forbidden due to lack of internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6887893db4d48327ae17c305f9a82cb9