### PR TITLE
Update documentation and swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# gestion-eleves-madvision
+# Gestion Eleves MadVision
+
+This repository contains the source code for both the **backend** and **frontend** of the MadVision student management application.
+
+- **`back_end/`** - Express server written in TypeScript. It exposes a REST API documented with Swagger.
+- **`gestion-eleves-front/`** - React frontend built with Vite and TypeScript.
+
+See the README file in each subdirectory for instructions on installing dependencies and running the projects.

--- a/back_end/README.md
+++ b/back_end/README.md
@@ -1,0 +1,14 @@
+# Backend
+
+This folder contains the Express API written in TypeScript and running with [Bun](https://bun.sh/).
+
+## Development
+
+Install dependencies and start the server:
+
+```bash
+bun install
+bun run dev
+```
+
+The API is documented with **Swagger**. Once the server is running, the documentation is available at `http://localhost:3000/docs`.

--- a/back_end/docs/eleveFourniture/swagger.ts
+++ b/back_end/docs/eleveFourniture/swagger.ts
@@ -1,0 +1,87 @@
+/**
+ * @swagger
+ * tags:
+ *   - name: EleveFourniture
+ *     description: Gestion des fournitures associées aux élèves
+ */
+
+/**
+ * @swagger
+ * /eleve-fournitures:
+ *   post:
+ *     tags: [EleveFourniture]
+ *     summary: Associer une fourniture à un élève
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [eleveId, fournitureId]
+ *             properties:
+ *               eleveId:
+ *                 type: integer
+ *               fournitureId:
+ *                 type: integer
+ *               paye:
+ *                 type: number
+ *                 default: 0
+ *     responses:
+ *       201:
+ *         description: Relation créée
+ *       400:
+ *         description: Erreur lors de la création
+ */
+
+/**
+ * @swagger
+ * /eleve-fournitures/{id}:
+ *   put:
+ *     tags: [EleveFourniture]
+ *     summary: Modifier la somme payée pour une fourniture d'un élève
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               paye:
+ *                 type: number
+ *     responses:
+ *       200:
+ *         description: Relation modifiée
+ *       400:
+ *         description: Erreur lors de la modification
+ */
+
+/**
+ * @swagger
+ * /eleve-fournitures/{id}:
+ *   delete:
+ *     tags: [EleveFourniture]
+ *     summary: Supprimer la fourniture d'un élève
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       204:
+ *         description: Relation supprimée
+ *       400:
+ *         description: Erreur lors de la suppression
+ */

--- a/back_end/docs/eleveModule/swagger.ts
+++ b/back_end/docs/eleveModule/swagger.ts
@@ -1,0 +1,87 @@
+/**
+ * @swagger
+ * tags:
+ *   - name: EleveModule
+ *     description: Gestion des modules associés aux élèves
+ */
+
+/**
+ * @swagger
+ * /eleve-modules:
+ *   post:
+ *     tags: [EleveModule]
+ *     summary: Associer un module à un élève
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [eleveId, moduleId]
+ *             properties:
+ *               eleveId:
+ *                 type: integer
+ *               moduleId:
+ *                 type: integer
+ *               paye:
+ *                 type: number
+ *                 default: 0
+ *     responses:
+ *       201:
+ *         description: Relation créée
+ *       400:
+ *         description: Erreur lors de la création
+ */
+
+/**
+ * @swagger
+ * /eleve-modules/{id}:
+ *   put:
+ *     tags: [EleveModule]
+ *     summary: Modifier la somme payée pour un module d'un élève
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               paye:
+ *                 type: number
+ *     responses:
+ *       200:
+ *         description: Relation modifiée
+ *       400:
+ *         description: Erreur lors de la modification
+ */
+
+/**
+ * @swagger
+ * /eleve-modules/{id}:
+ *   delete:
+ *     tags: [EleveModule]
+ *     summary: Supprimer le module d'un élève
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       204:
+ *         description: Relation supprimée
+ *       400:
+ *         description: Erreur lors de la suppression
+ */

--- a/back_end/docs/eleves/swagger.ts
+++ b/back_end/docs/eleves/swagger.ts
@@ -11,6 +11,8 @@
  *   get:
  *     tags: [Élèves]
  *     summary: Récupère la liste des élèves avec filtres, pagination, tri et somme due
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: query
  *         name: nomPrenom
@@ -84,6 +86,8 @@
  *   get:
  *     tags: [Élèves]
  *     summary: Récupère un élève complet avec ses relations
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -103,6 +107,8 @@
  *   post:
  *     tags: [Élèves]
  *     summary: Crée un nouvel élève avec ses modules, fournitures et reçus
+ *     security:
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -159,6 +165,8 @@
  *   patch:
  *     tags: [Élèves]
  *     summary: Ajoute des relations à un élève existant (modules, fournitures, reçus)
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -197,6 +205,8 @@
  *   put:
  *     tags: [Élèves]
  *     summary: Met à jour un élève et ses relations
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -249,6 +259,8 @@
  *   delete:
  *     tags: [Élèves]
  *     summary: Supprime un élève et toutes ses relations
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id

--- a/back_end/docs/export-import/swagger.ts
+++ b/back_end/docs/export-import/swagger.ts
@@ -1,0 +1,49 @@
+/**
+ * @swagger
+ * tags:
+ *   - name: ExportImport
+ *     description: Import et export de données CSV
+ */
+
+/**
+ * @swagger
+ * /export-import/import/csv:
+ *   post:
+ *     tags: [ExportImport]
+ *     summary: Importer des élèves depuis un fichier CSV
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *     responses:
+ *       200:
+ *         description: Import terminé
+ *       400:
+ *         description: Aucun fichier fourni ou erreur d'import
+ */
+
+/**
+ * @swagger
+ * /export-import/export/csv:
+ *   get:
+ *     tags: [ExportImport]
+ *     summary: Exporter toutes les données élèves au format CSV
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Fichier CSV généré
+ *         content:
+ *           text/csv:
+ *             schema:
+ *               type: string
+ *               format: binary
+ */

--- a/back_end/docs/filieres/swagger.ts
+++ b/back_end/docs/filieres/swagger.ts
@@ -30,7 +30,7 @@
  *     summary: Récupérer toutes les filières.
  *     tags: [Filiere]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: Liste de toutes les filières.
@@ -47,7 +47,7 @@
  *     summary: Créer une nouvelle filière.
  *     tags: [Filiere]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -74,7 +74,7 @@
  *     summary: Récupérer une filière par son ID.
  *     tags: [Filiere]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path
@@ -97,7 +97,7 @@
  *     summary: Mettre à jour une filière.
  *     tags: [Filiere]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path
@@ -128,7 +128,7 @@
  *     summary: Supprimer une filière.
  *     tags: [Filiere]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path

--- a/back_end/docs/fournitures/swagger.ts
+++ b/back_end/docs/fournitures/swagger.ts
@@ -35,7 +35,7 @@
  *     summary: Récupérer toutes les fournitures.
  *     tags: [Fourniture]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: Liste de toutes les fournitures.
@@ -52,7 +52,7 @@
  *     summary: Créer une nouvelle fourniture.
  *     tags: [Fourniture]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -79,7 +79,7 @@
  *     summary: Récupérer une fourniture par ID.
  *     tags: [Fourniture]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path
@@ -102,7 +102,7 @@
  *     summary: Mettre à jour une fourniture.
  *     tags: [Fourniture]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path
@@ -133,7 +133,7 @@
  *     summary: Supprimer une fourniture.
  *     tags: [Fourniture]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path

--- a/back_end/docs/modules/swagger.ts
+++ b/back_end/docs/modules/swagger.ts
@@ -27,7 +27,7 @@
  *     summary: Récupérer tous les modules.
  *     tags: [Module]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: Liste de tous les modules.
@@ -44,7 +44,7 @@
  *     summary: Créer un nouveau module.
  *     tags: [Module]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -68,7 +68,7 @@
  *     summary: Récupérer un module par son ID.
  *     tags: [Module]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path
@@ -92,7 +92,7 @@
  *     summary: Mettre à jour un module existant.
  *     tags: [Module]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path
@@ -124,7 +124,7 @@
  *     summary: Supprimer un module.
  *     tags: [Module]
  *     security:
- *       - bearerAuth: []
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path

--- a/back_end/docs/recus/swagger.ts
+++ b/back_end/docs/recus/swagger.ts
@@ -11,6 +11,8 @@
  *   get:
  *     tags: [Recus]
  *     summary: Liste des reçus
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: Liste des reçus
@@ -28,6 +30,8 @@
  *   post:
  *     tags: [Recus]
  *     summary: Créer un nouveau reçu
+ *     security:
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -53,6 +57,8 @@
  *   get:
  *     tags: [Recus]
  *     summary: Détail d'un reçu
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -70,6 +76,8 @@
  *   put:
  *     tags: [Recus]
  *     summary: Modifier un reçu
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -98,6 +106,8 @@
  *   delete:
  *     tags: [Recus]
  *     summary: Supprimer un reçu
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id

--- a/back_end/docs/stats/swagger.ts
+++ b/back_end/docs/stats/swagger.ts
@@ -11,6 +11,8 @@
  *   get:
  *     tags: [Statistiques]
  *     summary: Nombre d'élèves par filière
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: Liste des filières avec nombre d'élèves
@@ -33,6 +35,8 @@
  *   get:
  *     tags: [Statistiques]
  *     summary: Montant total encaissé (somme des reçus)
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: Montant total encaissé
@@ -49,6 +53,25 @@
 /**
  * @swagger
  * /stats/eleves-en-retard:
+ *   get:
+ *     tags: [Statistiques]
+ *     summary: Élèves ayant des paiements en retard
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Liste des élèves en retard de paiement
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   eleve:
+ *                     type: string
+ *                   montantRestant:
+ *                     type: number
  */
 
 /**
@@ -57,6 +80,8 @@
  *   get:
  *     tags: [Statistiques]
  *     summary: Modules les plus suivis (triés par nombre d'élèves)
+ *     security:
+ *       - BearerAuth: []
  *     responses:
  *       200:
  *         description: Liste des modules avec nombre d'élèves inscrits

--- a/back_end/server.ts
+++ b/back_end/server.ts
@@ -42,7 +42,7 @@ const swaggerOptions = {
         },
         security: [{ BearerAuth: [] }],
     },
-    apis: ["docs/**/*.ts", "back_end/docs/**/*.ts"],
+    apis: ["back_end/docs/**/*.ts"],
 };
 
 const swaggerDocs = swaggerJsdoc(swaggerOptions);

--- a/gestion-eleves-front/README.md
+++ b/gestion-eleves-front/README.md
@@ -1,69 +1,14 @@
-# React + TypeScript + Vite
+# Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This application is a React client built with Vite.
 
-Currently, two official plugins are available:
+## Development
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Install dependencies and start the dev server:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+bun install
+bun run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+The app will be available at `http://localhost:5173/` by default.


### PR DESCRIPTION
## Summary
- add Swagger docs for eleve-fournitures routes
- add Swagger docs for eleve-modules routes
- document CSV import/export endpoints
- flesh out stats documentation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887869ff084832795786c61dd8a0928