### PR TITLE
Refactor to use shared Prisma client

### DIFF
--- a/back_end/routes/eleveFourniture/index.ts
+++ b/back_end/routes/eleveFourniture/index.ts
@@ -1,14 +1,12 @@
 import { Router, Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { db } from "../../db";
 const eleveFournitureRouter = Router();
 
 eleveFournitureRouter.post("/", async (req: Request, res: Response) => {
     const { eleveId, fournitureId, paye = 0 } = req.body;
 
     try {
-        const created = await prisma.eleveFourniture.create({
+        const created = await db.eleveFourniture.create({
             data: {
                 eleveId,
                 fournitureId,
@@ -26,7 +24,7 @@ eleveFournitureRouter.put("/:id", async (req: Request, res: Response) => {
     const { paye } = req.body;
 
     try {
-        const updated = await prisma.eleveFourniture.update({
+        const updated = await db.eleveFourniture.update({
             where: { id },
             data: { paye },
         });
@@ -40,7 +38,7 @@ eleveFournitureRouter.delete("/:id", async (req: Request, res: Response) => {
     const id = Number(req.params.id);
 
     try {
-        await prisma.eleveFourniture.delete({ where: { id } });
+        await db.eleveFourniture.delete({ where: { id } });
         res.sendStatus(204);
     } catch (error) {
         res.status(400).json({ error: "Erreur lors de la suppression", details: error });

--- a/back_end/routes/eleveModule/index.ts
+++ b/back_end/routes/eleveModule/index.ts
@@ -1,14 +1,12 @@
 import { Router, Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { db } from "../../db";
 const eleveModuleRouter = Router();
 
 eleveModuleRouter.post("/", async (req: Request, res: Response) => {
     const { eleveId, moduleId, paye = 0 } = req.body;
 
     try {
-        const created = await prisma.eleveModule.create({
+        const created = await db.eleveModule.create({
             data: {
                 eleveId,
                 moduleId,
@@ -26,7 +24,7 @@ eleveModuleRouter.put("/:id", async (req: Request, res: Response) => {
     const { paye } = req.body;
 
     try {
-        const updated = await prisma.eleveModule.update({
+        const updated = await db.eleveModule.update({
             where: { id },
             data: { paye },
         });
@@ -40,7 +38,7 @@ eleveModuleRouter.delete("/:id", async (req: Request, res: Response) => {
     const id = Number(req.params.id);
 
     try {
-        await prisma.eleveModule.delete({ where: { id } });
+        await db.eleveModule.delete({ where: { id } });
         res.sendStatus(204);
     } catch (error) {
         res.status(400).json({ error: "Erreur lors de la suppression", details: error });

--- a/back_end/routes/filieres/index.ts
+++ b/back_end/routes/filieres/index.ts
@@ -1,13 +1,11 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { db } from "../../db";
 const filiereRouter = Router();
 
 // GET /filieres - Get all filieres
 filiereRouter.get('/', async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const filieres = await prisma.filiere.findMany();
+        const filieres = await db.filiere.findMany();
         res.json({
             data: filieres,
             total: filieres.length,
@@ -25,7 +23,7 @@ filiereRouter.get('/:id', async (req: Request, res: Response, next: NextFunction
             res.status(400).json({ message: 'ID invalide' });
             return;
         }
-        const filiere = await prisma.filiere.findUnique({ where: { id } });
+        const filiere = await db.filiere.findUnique({ where: { id } });
         if (!filiere) {
             res.status(404).json({ message: 'Filiere introuvable' });
             return;
@@ -44,7 +42,7 @@ filiereRouter.post('/', async (req: Request, res: Response, next: NextFunction) 
             res.status(400).json({ message: 'Paramètres invalides' });
             return;
         }
-        const newFiliere = await prisma.filiere.create({ data: { nom } });
+        const newFiliere = await db.filiere.create({ data: { nom } });
         res.status(201).json(newFiliere);
     } catch (error) {
         next(error);
@@ -64,7 +62,7 @@ filiereRouter.put('/:id', async (req: Request, res: Response, next: NextFunction
             res.status(400).json({ message: 'Paramètres invalides' });
             return;
         }
-        const updatedFiliere = await prisma.filiere.update({
+        const updatedFiliere = await db.filiere.update({
             where: { id },
             data: { nom }
         });
@@ -86,7 +84,7 @@ filiereRouter.delete('/:id', async (req: Request, res: Response, next: NextFunct
             res.status(400).json({ message: 'ID invalide' });
             return;
         }
-        await prisma.filiere.delete({ where: { id } });
+        await db.filiere.delete({ where: { id } });
         res.sendStatus(204);
     } catch (error: any) {
         if (error.code === 'P2025') {

--- a/back_end/routes/fournitures/index.ts
+++ b/back_end/routes/fournitures/index.ts
@@ -1,13 +1,11 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { db } from "../../db";
 const fournitureRouter = Router();
 
 // GET /fournitures - Get all fournitures
 fournitureRouter.get('/', async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const fournitures = await prisma.fourniture.findMany();
+        const fournitures = await db.fourniture.findMany();
         res.json({
             data: fournitures,
             total: fournitures.length,
@@ -25,7 +23,7 @@ fournitureRouter.get('/:id', async (req: Request, res: Response, next: NextFunct
             res.status(400).json({ message: 'ID invalide' });
             return;
         }
-        const fourniture = await prisma.fourniture.findUnique({ where: { id } });
+        const fourniture = await db.fourniture.findUnique({ where: { id } });
         if (!fourniture) {
             res.status(404).json({ message: 'Fourniture introuvable' });
             return;
@@ -44,7 +42,7 @@ fournitureRouter.post('/', async (req: Request, res: Response, next: NextFunctio
             res.status(400).json({ message: 'Paramètres invalides' });
             return;
         }
-        const newFourniture = await prisma.fourniture.create({ data: { nom, prix } });
+        const newFourniture = await db.fourniture.create({ data: { nom, prix } });
         res.status(201).json(newFourniture);
     } catch (error) {
         next(error);
@@ -64,7 +62,7 @@ fournitureRouter.put('/:id', async (req: Request, res: Response, next: NextFunct
             res.status(400).json({ message: 'Paramètres invalides' });
             return;
         }
-        const updatedFourniture = await prisma.fourniture.update({
+        const updatedFourniture = await db.fourniture.update({
             where: { id },
             data: { nom, prix }
         });
@@ -86,7 +84,7 @@ fournitureRouter.delete('/:id', async (req: Request, res: Response, next: NextFu
             res.status(400).json({ message: 'ID invalide' });
             return;
         }
-        await prisma.fourniture.delete({ where: { id } });
+        await db.fourniture.delete({ where: { id } });
         res.sendStatus(204);
     } catch (error: any) {
         if (error.code === 'P2025') {

--- a/back_end/routes/modules/index.ts
+++ b/back_end/routes/modules/index.ts
@@ -1,13 +1,11 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { db } from "../../db";
 const moduleRouter = Router();
 
 // GET /modules - Get all modules
 moduleRouter.get("/", async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const modules = await prisma.module.findMany();
+        const modules = await db.module.findMany();
         res.json({
             data: modules,
             total: modules.length,
@@ -25,7 +23,7 @@ moduleRouter.get('/:id', async (req: Request, res: Response, next: NextFunction)
             res.status(400).json({ message: 'ID invalide' });
             return;
         }
-        const moduleItem = await prisma.module.findUnique({ where: { id } });
+        const moduleItem = await db.module.findUnique({ where: { id } });
         if (!moduleItem) {
             res.status(404).json({ message: 'Module introuvable' });
             return;
@@ -44,7 +42,7 @@ moduleRouter.post('/', async (req: Request, res: Response, next: NextFunction) =
             res.status(400).json({ message: 'Paramètres invalides' });
             return;
         }
-        const newModule = await prisma.module.create({
+        const newModule = await db.module.create({
             data: { nom, prix: Number(prix) },
         });
         res.status(201).json(newModule);
@@ -66,7 +64,7 @@ moduleRouter.put('/:id', async (req: Request, res: Response, next: NextFunction)
             res.status(400).json({ message: 'Paramètres invalides' });
             return;
         }
-        const updatedModule = await prisma.module.update({
+        const updatedModule = await db.module.update({
             where: { id },
             data: { nom, prix: Number(prix) },
         });
@@ -88,7 +86,7 @@ moduleRouter.delete('/:id', async (req: Request, res: Response, next: NextFuncti
             res.status(400).json({ message: 'ID invalide' });
             return;
         }
-        await prisma.module.delete({ where: { id } });
+        await db.module.delete({ where: { id } });
         res.sendStatus(204);
     } catch (error: any) {
         if (error.code === 'P2025') {


### PR DESCRIPTION
## Summary
- add a central `db.ts` file exporting a shared `PrismaClient`
- use the shared client in filiere, module, fourniture, and import/export routes
- update eleveModule and eleveFourniture routes to import the shared client

## Testing
- `bunx tsc -p back_end/tsconfig.json` *(fails: Cannot find module '@prisma/client', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887893d72008327a592dc49bba473cc